### PR TITLE
[LCAP-3725] Add function to HTMLify marc

### DIFF
--- a/util-service/server.js
+++ b/util-service/server.js
@@ -2366,7 +2366,7 @@ function marcRecordHtmlify(data){
 			formatedMarcRecord.push("<span class='marc field'>"+ tag + value + "</span>")
 		} else {
 			//fields with subfields
-			subfields = subfields.map((subfield) => "<span class='marc subfield subfield-" + subfield[0] + "'><span class='marc subfield subfield-label'>$"+subfield[0] +"</span> <span class='marc subfield subfield-value'>" + subfield[1] +"</span></span></span>")
+			subfields = subfields.map((subfield) => "<span class='marc subfield subfield-" + subfield[0] + "'><span class='marc subfield subfield-label'>$"+subfield[0] +"</span> <span class='marc subfield subfield-value'>" + subfield[1] +"</span></span>")
 			indicators = "<span class='marc indicators'><span class='marc indiccators indicator-1'>" + indicators[0] + "</span><span class='marc indiccators indicator-2'>" + indicators[1] + "</span></span>"
 			tag = "<span class='marc tag tag-" + tag + "'>" + tag + "</span>"
 			formatedMarcRecord.push("<span class='marc field'>"+ tag + indicators + subfields.join(" ") + "</span>")

--- a/util-service/server.js
+++ b/util-service/server.js
@@ -2367,7 +2367,7 @@ function marcRecordHtmlify(data){
 		} else {
 			//fields with subfields
 			subfields = subfields.map((subfield) => "<span class='marc subfield subfield-" + subfield[0] + "'><span class='marc subfield subfield-label'>$"+subfield[0] +"</span> <span class='marc subfield subfield-value'>" + subfield[1] +"</span></span>")
-			indicators = "<span class='marc indicators'><span class='marc indiccators indicator-1'>" + indicators[0] + "</span><span class='marc indiccators indicator-2'>" + indicators[1] + "</span></span>"
+			indicators = "<span class='marc indicators'><span class='marc indicators indicator-1'>" + indicators[0] + "</span><span class='marc indiccators indicator-2'>" + indicators[1] + "</span></span>"
 			tag = "<span class='marc tag tag-" + tag + "'>" + tag + "</span>"
 			formatedMarcRecord.push("<span class='marc field'>"+ tag + indicators + subfields.join(" ") + "</span>")
 		}


### PR DESCRIPTION
Ticket: https://staff.loc.gov/tasks/browse/LCAP-3725

This starts to address the ticket.

Instead of passing a string of MARC to Marva, the function will wrap everything in HTML to allow styling different pieces as desired.

The function is in the backend, but not being called. I need to fake the backend inorder to, so it's difficult to test.

I tried to format it so that each part that might need a different style has a separate class.

```html
<span class="marc field">
  <span class="marc tag tag-'tag#' />
  <span class="marc indicators>
    <span class='marc indicators indicator-1' />
    <span class='marc indicators indicator-2' />
  </span>
  <span class='marc subfield subfield-`subfieldvalue1`'>
      <span class='marc subfield subfield-label' />
      <span class='marc subfield subfield-value' />
  </span>
  <span class='marc subfield subfield-`subfieldvalue-n`'>
      <span class='marc subfield subfield-label' />
      <span class='marc subfield subfield-value' />
  </span>
</span>
```