### PR TITLE
[BFP 236] Expand catching `xml:lang` attribute

### DIFF
--- a/util-service/server.js
+++ b/util-service/server.js
@@ -2304,7 +2304,8 @@ app.post('/marcpreview/:type', async (request, response) => {
 
 			x = x.replace(/\s+xml:space="preserve">/g,'>')
 			x = x.replace(/\s+xml:space="preserve"\s+/g,' ')
-			x = x.replace(/\s+xml:lang="en"\s+/g,' ')
+			// x = x.replace(/\s+xml:lang="en"\s+/g,' ')
+			x = x.replace(/\s+xml:lang=".*"[\s+>]/g,' ')     //match and remove all `xml:lang="..."` instances
 
 
 			x = x.replace(/<marc:/g,'<')


### PR DESCRIPTION
Jira: https://staff.loc.gov/tasks/browse/BFP-236

There was a previous fix that looked for `xml:lang="en"`. But there can be issues with other languages, so the RegEx needs to be expanded to account for them.

Prev pattern: `\s+xml:lang="en"\s+`
New Pattern:       `\s+xml:lang=".*"[\s+>]`